### PR TITLE
Upgrade to newest juicebox to be D9 compatible

### DIFF
--- a/drupal/composer.json
+++ b/drupal/composer.json
@@ -26,7 +26,7 @@
     "drupal/admin_toolbar": "^3.0.2",
     "drupal/video_embed_field": "^2.4",
     "drupal/stage_file_proxy": "~1.0",
-    "drupal/juicebox": "~2.0",
+    "drupal/juicebox": "^3.0",
     "drupal/inline_entity_form": "~1.0",
     "drupal/node_view_permissions": "~1.0",
     "drupal/entity_browser": "~1.0",
@@ -41,7 +41,8 @@
     "drupal/google_tag": "^1",
     "drupal/redis": "^1.5",
     "predis/predis": "^1.1",
-    "drupal/core-recommended": "^8.9"
+    "drupal/core-recommended": "^8.9",
+    "drupal/libraries": "^3.0"
   },
   "require-dev": {
     "jcalderonzumba/gastonjs": "^1.1@dev",

--- a/drupal/composer.lock
+++ b/drupal/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a607e6af5c470536fc504c1ae619649a",
+    "content-hash": "a656c2751e65daa4c73b5bf51465918a",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2927,30 +2927,29 @@
         },
         {
             "name": "drupal/juicebox",
-            "version": "2.0.0-beta4",
+            "version": "3.0.0-alpha2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/juicebox.git",
-                "reference": "8.x-2.0-beta4"
+                "reference": "8.x-3.0-alpha2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/juicebox-8.x-2.0-beta4.zip",
-                "reference": "8.x-2.0-beta4",
-                "shasum": "743b0ecc85724d58d3444c33751f8c737801c464"
+                "url": "https://ftp.drupal.org/files/projects/juicebox-8.x-3.0-alpha2.zip",
+                "reference": "8.x-3.0-alpha2",
+                "shasum": "ff73f99e8285c2f8eccfb6b3563a3de1dc17c144"
             },
             "require": {
-                "drupal/core": "^8",
-                "drupal/libraries": "*"
+                "drupal/core": "^8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.0-beta4",
-                    "datestamp": "1596048775",
+                    "version": "8.x-3.0-alpha2",
+                    "datestamp": "1608186079",
                     "security-coverage": {
                         "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
+                        "message": "Alpha releases are not covered by Drupal security advisories."
                     }
                 }
             },
@@ -8430,5 +8429,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
Juicebox drops its use of libraries, so we add it in as an explicit '
requirement, and will then uninstall and remove it later
